### PR TITLE
Upgrade to .NET 9.0

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   npgsql-dev:
-    image: mcr.microsoft.com/dotnet/sdk:7.0
+    image: mcr.microsoft.com/dotnet/sdk:9.0
     volumes:
       - ..:/workspace:cached
     tty: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  dotnet_sdk_version: '7.0.100'
+  dotnet_sdk_version: '9.0.105'
   postgis_version: 3
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   # Windows comes with PG pre-installed, and defines the PGPASSWORD environment variable. Remove it as it interferes
@@ -25,14 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        pg_major: [15, 14, 13, 12, 11, 10]
+        pg_major: [17, 16, 15, 14, 13, 12, 11, 10]
         config: [Release]
-        test_tfm: [net7.0]
+        test_tfm: [net9.0]
         include:
           - os: ubuntu-22.04
             pg_major: 15
             config: Debug
-            test_tfm: net7.0
+            test_tfm: net9.0
           - os: ubuntu-22.04
             pg_major: 15
             config: Release
@@ -40,7 +40,7 @@ jobs:
           - os: macos-12
             pg_major: 14
             config: Release
-            test_tfm: net7.0
+            test_tfm: net9.0
 #          - os: ubuntu-22.04
 #            pg_major: 15
 #            config: Release

--- a/.github/workflows/rich-code-nav.yml
+++ b/.github/workflows/rich-code-nav.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  dotnet_sdk_version: '7.0.100'
+  dotnet_sdk_version: '9.0.105'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>Shay Rojansky</Authors>
-    <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
+    <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to
+      NodaTime types.</Description>
     <PackageTags>npgsql;postgresql;postgres;nodatime;date;time;ado;ado;net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -12,13 +13,14 @@
     <PackageReference Include="NodaTime" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />
-    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
+    <Authors>Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil
+      Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json, which is
+    <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json,
+    which is
          necessary for older TFMs. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
@@ -37,17 +40,20 @@
     <PackageReference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
+  <ItemGroup
+    Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup
+    Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup
+    Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 

--- a/src/Npgsql/NpgsqlDataReaderOrig.cs
+++ b/src/Npgsql/NpgsqlDataReaderOrig.cs
@@ -1189,7 +1189,7 @@ public class NpgsqlDataReaderOrig : DbDataReader, IDbColumnSchemaGenerator
                 catch (Exception e)
                 {
                     // TODO: think of a better way to handle exceptions, see #1323 and #3163
-                    _commandLogger.LogDebug(e, "Exception caught while sending the request", Connector.Id);
+                    _commandLogger.LogDebug(e, "Exception caught while sending the request {Id}", Connector.Id);
                 }
             }
         }

--- a/src/Npgsql/NpgsqlException.cs
+++ b/src/Npgsql/NpgsqlException.cs
@@ -70,6 +70,7 @@ public class NpgsqlException : DbException
     /// </summary>
     /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
     /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+    [Obsolete(DiagnosticId = "SYSLIB0051")]
     protected internal NpgsqlException(SerializationInfo info, StreamingContext context) : base(info, context) {}
 
     #endregion

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTypes.csproj
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTypes.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
+    <Authors>Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil
+      Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json, which is
+    <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json,
+    which is
          necessary for older TFMs. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net9.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -110,6 +110,7 @@ public sealed class PostgresException : NpgsqlException
     internal static PostgresException Load(NpgsqlReadBuffer buf, bool includeDetail, ILogger exceptionLogger)
         => new(ErrorOrNoticeMessage.Load(buf, includeDetail, exceptionLogger));
 
+    [Obsolete(DiagnosticId = "SYSLIB0051")]
     internal PostgresException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
@@ -140,6 +141,7 @@ public sealed class PostgresException : NpgsqlException
     /// </summary>
     /// <param name="info">The <see cref="SerializationInfo"/> to populate with data.</param>
     /// <param name="context">The destination (see <see cref="StreamingContext"/>) for this serialization.</param>
+    [Obsolete]
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,11 +2,12 @@
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
-    <!-- Suppress warnings for [RequiresPreviewFeatures] (<EnablePreviewFeatures> doesn't seem to work across <ProjectReference>) -->
+    <!-- Suppress warnings for [RequiresPreviewFeatures] (<EnablePreviewFeatures> doesn't seem to
+    work across <ProjectReference>) -->
     <NoWarn>$(NoWarn);CA2252</NoWarn>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -746,7 +746,9 @@ INSERT INTO {table} (bits, bitarray) VALUES (B'101', ARRAY[B'101', B'111'])");
         // This must be large enough to cause Postgres to queue up CopyData messages.
         var stream = conn.BeginRawBinaryCopy("COPY (select md5(random()::text) as id from generate_series(1, 100000)) TO STDOUT BINARY");
         var buffer = new byte[32];
+#pragma warning disable CA2022 // Avoid inexact read with 'Stream.Read'
         await stream.ReadAsync(buffer, 0, buffer.Length);
+#pragma warning restore CA2022 // Avoid inexact read with 'Stream.Read'
         stream.Cancel();
         Assert.DoesNotThrowAsync(async () => await stream.DisposeAsync());
         Assert.That(async () => await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1), "The connection is still OK");

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -221,6 +221,7 @@ $$ LANGUAGE 'plpgsql';");
         PostgresException CreateWithSqlState(string sqlState)
         {
             var info = CreateSerializationInfo();
+            #pragma warning disable SYSLIB0051
             new Exception().GetObjectData(info, default);
 
             info.AddValue(nameof(PostgresException.Severity), null);
@@ -282,6 +283,7 @@ $$ LANGUAGE 'plpgsql';");
         Assert.That(expected.Routine, Is.EqualTo(actual.Routine));
     }
 
+#pragma warning disable SYSLIB0050
     SerializationInfo CreateSerializationInfo() => new(typeof(PostgresException), new FormatterConverter());
 #pragma warning restore 618
 #pragma warning restore SYSLIB0011

--- a/test/Npgsql.Tests/LargeObjectTests.cs
+++ b/test/Npgsql.Tests/LargeObjectTests.cs
@@ -19,7 +19,9 @@ public class LargeObjectTests : TestBase
             stream.Write(buf, 0, buf.Length);
             stream.Seek(0, System.IO.SeekOrigin.Begin);
             var buf2 = new byte[buf.Length];
+#pragma warning disable CA2022 // Avoid inexact read with 'Stream.Read'
             stream.Read(buf2, 0, buf2.Length);
+#pragma warning restore CA2022 // Avoid inexact read with 'Stream.Read'
             Assert.That(buf.SequenceEqual(buf2));
 
             Assert.AreEqual(5, stream.Position);


### PR DESCRIPTION
This pull request updates the `npgsql` fork to target **.NET 9**, ensuring compatibility with the latest .NET framework used in the `pldotnet` project. The changes include updating the target framework and making necessary code adjustments to accommodate .NET 9's features and requirements.

### Changes Made

- **Target Framework Update:** Changed the target framework to `.NET 9` in the project files.
- **Code Adjustments:** Modified code across 11 files to address any breaking changes and deprecations introduced in .NET 9.